### PR TITLE
Fix exception when calling init for server with no middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,9 @@ function middlewareExists(app, name) {
 	//From http://stackoverflow.com/questions/26304234/check-if-a-given-middleware-is-being-used
 	//filter checks each element, and !! converts filter's return type (an array of booleans) to 
 	//a boolean type
+    if (!app._router) {
+        return false
+    }
 	return !!app._router.stack.filter(function (layer) { 
 		return layer && layer.handle && layer.handle.name === name; 
     }).length;


### PR DESCRIPTION
I was getting the error shown below:

 ```log
  1  /home/k/pavlok-punctual/node_modules/pavlok-beta-api-login/index.js:50
  2         return !!app._router.stack.filter(function (layer) {
  3                             ^
  4
  5 TypeError: Cannot read property 'stack' of undefined
  6     at middlewareExists (/home/k/pavlok-punctual/node_modules/pavlok-beta-api-login/index.js:50:22)
  7     at Object.exports.init (/home/k/pavlok-punctual/node_modules/pavlok-beta-api-login/index.js:168:7)
  8     at Object.<anonymous> (/home/k/pavlok-punctual/app.js:5:8)
  9     at Module._compile (module.js:571:32)
 10     at Object.Module._extensions..js (module.js:580:10)
 11     at Module.load (module.js:488:32)
 12     at tryModuleLoad (module.js:447:12)
 13     at Function.Module._load (module.js:439:3)
 14     at Module.runMain (module.js:605:10)
 15     at run (bootstrap_node.js:427:7)
```

When running a simple server with no middleware, e.g.:

```javascript
var pavlok = require('pavlok-beta-api-login');

pavlok.init("7f53e074cafe5151525a0934586bd39d4f7bc1156e67d53b862b9fa3dea1c6bd",
            "ff355d4688bc72b9641035a0edb8a8b569e67a305e32cf5fe329e9525b324513", {
    "verbose": true,
    "app" : app,
    "message": "Hello! Stay punctual or else...",
    "callbackUrl": "http://www.io.k33.me:3000/pavlok/result",
    "callbackUrlPath": "/pavlok/result",
    "successUrl": "/success",
    "errorUrl": "/error"
});
```
It started working after I added a simple middleware before the `.init` call, so I I added an if statement to cover this case.